### PR TITLE
Add Electron 2.0 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,8 @@ matrix:
   include:
     - node_js: 8
       env: ELECTRON_VERSION="1.8.3"
+    - node_js: '8.9.3'
+      env: ELECTRON_VERSION="2.0.2"
 
 install:
   - export PACKAGE_VERSION=`node -p "require('./package.json').version"`

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "main": "index.js",
   "name": "nseventmonitor",
-  "version": "0.0.8",
+  "version": "0.0.9",
   "repository": {
     "type": "github",
     "url": "https://github.com/mullvad/nseventmonitor"


### PR DESCRIPTION
This PR adds support for Electron 2.0.2. Node 8 and 8.9.3 actually share the same ABI so it's likely that the same binary is built twice but I didn't want to spend time trying to decouple targets which currently come with node and electron versions side-by-side.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/nseventmonitor/9)
<!-- Reviewable:end -->
