### PR TITLE
Fix deprecated call

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,18 +15,24 @@ matrix:
 install:
   - export PACKAGE_VERSION=`node -p "require('./package.json').version"`
 
+  # install electron for tests
+  - npm install --global electron@$ELECTRON_VERSION
+
+  # query electron's abi
+  - export ELECTRON_ABI=`npx electron --abi`
+
   # build for nodejs
   - npm install --build-from-source
 
+  # rebuild robotjs for electron
+  - npm rebuild --runtime=electron --target=$ELECTRON_VERSION --disturl=https://atom.io/download/atom-shell --abi=$ELECTRON_ABI
+
   # build for electron
-  - npm install --build-from-source --runtime=electron --target=$ELECTRON_VERSION --dist-url=https://atom.io/download/atom-shell
+  - npm install --build-from-source --runtime=electron --target=$ELECTRON_VERSION --disturl=https://atom.io/download/atom-shell --abi=$ELECTRON_ABI
 
   # package artifacts
   - if [[ "${TRAVIS_TAG}" != "" ]]; then npm run package --verbose; fi
   - if [[ "${TRAVIS_TAG}" != "" ]]; then npm run package --runtime=electron --target=$ELECTRON_VERSION --verbose; fi
-
-  # install electron for tests
-  - npm install --global electron@$ELECTRON_VERSION
 
 script:
   - npm run test

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "nseventmonitor",
-  "version": "0.0.11",
+  "version": "0.0.12",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "main": "index.js",
   "name": "nseventmonitor",
-  "version": "0.0.11",
+  "version": "0.0.12",
   "repository": {
     "type": "github",
     "url": "https://github.com/mullvad/nseventmonitor"

--- a/src/NSEventMonitor.mm
+++ b/src/NSEventMonitor.mm
@@ -31,10 +31,11 @@ void addon::NSEventMonitor::EmitEvent(NSEvent *event) {
 
 void addon::NSEventMonitor::StartMonitoring(v8::Persistent<v8::Number> &eventMask, v8::Persistent<v8::Function> &callback) {
   v8::Isolate *isolate = v8::Isolate::GetCurrent();
+  v8::Local<v8::Context> context = isolate->GetCurrentContext();
   v8::HandleScope scope(isolate);
 
   v8::Local<v8::Number> mask = v8::Local<v8::Number>::New(isolate, eventMask);
-  NSEventMask nsEventMask = static_cast<NSEventMask>(mask->IntegerValue());
+  NSEventMask nsEventMask = static_cast<NSEventMask>(mask->IntegerValue(context).ToChecked());
 
   StopMonitoring();
 


### PR DESCRIPTION
a call to `IntegerValue` has been deprecated in node 11:

```cpp
V8_DEPRECATED("Use maybe version", int64_t IntegerValue() const);
```

Suggested way to achieve the same now is to go via `Maybe<T>` and unwrap the value manually.

```cpp
V8_WARN_UNUSED_RESULT Maybe<int64_t> IntegerValue(
      Local<Context> context) const;
```

Fixes #12 too