### PR TITLE
Add electron 8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,6 +15,8 @@ matrix:
       env: ELECTRON_VERSION="6.0.2"
     - node_js: '12.8.1'
       env: ELECTRON_VERSION="7.1.9"
+    - node_js: '12.13.0'
+      env: ELECTRON_VERSION="8.2.0"
 
 install:
   - export PACKAGE_VERSION=`node -p "require('./package.json').version"`

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "nseventmonitor",
-  "version": "0.0.17",
+  "version": "0.0.18",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "main": "index.js",
   "name": "nseventmonitor",
-  "version": "0.0.17",
+  "version": "0.0.18",
   "repository": {
     "type": "github",
     "url": "https://github.com/mullvad/nseventmonitor"


### PR DESCRIPTION
This PR adds electron 8 and its corresponding node version to .travis.yml and bumps the version number to 0.0.18