### PR TITLE
Move nan to dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -818,8 +818,7 @@
     "nan": {
       "version": "2.14.2",
       "resolved": "https://registry.npmjs.org/nan/-/nan-2.14.2.tgz",
-      "integrity": "sha512-M2ufzIiINKCuDfBSAUr1vWQ+vuVcA9kqx8JJUsbQi6yf1uGRyb7HfpdfUr5qLXf3B/t8dPvcjhKMmlfnP47EzQ==",
-      "dev": true
+      "integrity": "sha512-M2ufzIiINKCuDfBSAUr1vWQ+vuVcA9kqx8JJUsbQi6yf1uGRyb7HfpdfUr5qLXf3B/t8dPvcjhKMmlfnP47EzQ=="
     },
     "nanoid": {
       "version": "3.1.12",

--- a/package.json
+++ b/package.json
@@ -20,10 +20,10 @@
   },
   "devDependencies": {
     "chai": "^4.2.0",
-    "electron-mocha": "^9.3.2",
-    "nan": "^2.14.2"
+    "electron-mocha": "^9.3.2"
   },
   "dependencies": {
+    "nan": "^2.14.2",
     "node-pre-gyp": "^0.16.0"
   },
   "os": [


### PR DESCRIPTION
This PR moves `nan` from `devDependencies` to `dependencies`, because `node-pre-gyp install --fallback-to-build` that runs from `install` script needs `nan` to be installed at the time of its execution & it's essential for building `NSEventMonitor`