### PR TITLE
Stop including binaries in releases

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -35,22 +35,6 @@ install:
   # build for electron
   - npm install --build-from-source --runtime=electron --target=$ELECTRON_VERSION --disturl=https://atom.io/download/atom-shell --abi=$ELECTRON_ABI
 
-  # package artifacts
-  - if [[ "${TRAVIS_TAG}" != "" ]]; then
-      npm run package --verbose;
-      npm run package --runtime=electron --target=$ELECTRON_VERSION --verbose;
-    fi
-
 script:
   # - npm run test
   - echo "Tests are disabled due to issues with automating clicks on macOS"
-
-deploy:
-  provider: releases
-  api_key:
-    secure: jULXPVDjuydr82/lNKc5Uk0tC724Pk8EzpONeCrW1KQkLvkJFiUlqe08vuEgW1CBxFbC/bXVOnxW2zfuxr9bBVyawkQOJmxxEdMGAW4hp6QFHywS/DOO5GfxsYsiwdPh94SUWb3XAWde20cCDr1PYbiPEZuV+1vxa2IgyCcBDhpzZohWcjlnI9/cnF7dvHrhW4kKpb0/YyDJAa4eYfaanA0gryxI5voylMAwnP/WIEJ7sllhqWfUU1PlKJThyM7F90mYCi5t+X8be//LzYkfQComFBw+leB/Ez4yYNKOXvr3U73ukfNNBQw0G7K6N/7z1hSOHrLRTxAdsnn6ltZZyJNs68arfQWbG2VuZIsg+35eaLvvSw16O6rGcCgVXYMbZlSOApzxeEVjOjOcQBpk+ViE9OYpHqpydpwRQgKkygUSNybfOzUhnTgo+yUoqSb6IaHTxphBPBz+Ngmmnvl8q63GHnN8CNhtuPOtk2IvQAfTUfQ3Hm9AO90K7j8NyyDpEYqdrPA+O9FzQ9LNtoH3rE1SxIzqoWDGuIgav1BhAXwd5pVjU5F0hLWQvryJ4f9MhHUUmroANLYDPQiK74DhdK8D9w7xAyUK1tMoYKePMiL2hAQMSo9k/fLr65dmbgFGNb6Nesisp0YLHEtkSsW8Wt4+VINEhXLx/GDrQ1WfM98=
-  file_glob: true
-  file: build/stage/$PACKAGE_VERSION/*.tar.gz
-  skip_cleanup: true
-  on:
-    tags: true

--- a/README.md
+++ b/README.md
@@ -21,8 +21,6 @@ window.on('blur', () => {
 });
 
 window.on('show', () => {
-  tray.setHighlightMode('always');
-
   // start capturing global mouse events
   macEventMonitor.start((NSEventMask.leftMouseDown | NSEventMask.rightMouseDown), () => {
     window.hide();
@@ -30,8 +28,6 @@ window.on('show', () => {
 });
 
 window.on('hide', () => {
-  tray.setHighlightMode('never');
-
   // stop capturing global mouse events
   macEventMonitor.stop();
 });

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "nseventmonitor",
-  "version": "0.0.20",
+  "version": "1.0.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -8,15 +8,14 @@
   },
   "license": "MIT",
   "scripts": {
-    "install": "node-pre-gyp install --fallback-to-build",
+    "install": "node-pre-gyp install --build-from-source",
     "package": "node-pre-gyp package",
     "test": "electron-mocha"
   },
   "binary": {
     "module_name": "nseventmonitor",
     "module_path": "./lib/binding/{configuration}/{node_abi}-{platform}-{arch}/",
-    "host": "https://github.com/mullvad/nseventmonitor/releases/download/",
-    "remote_path": "{version}"
+    "host": "https://github.com/mullvad/nseventmonitor/releases/download/"
   },
   "devDependencies": {
     "chai": "^4.2.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "main": "index.js",
   "name": "nseventmonitor",
-  "version": "0.0.20",
+  "version": "1.0.0",
   "repository": {
     "type": "github",
     "url": "https://github.com/mullvad/nseventmonitor"


### PR DESCRIPTION
This PR changes the Travis configuration to not include binaries in releases. This allows for more consistent behavior when switching between Electron versions. It's also more secure to build the library yourself.